### PR TITLE
Fix jamdict thread errors and correct furigana readings

### DIFF
--- a/src/furigana_ocr/core/__init__.py
+++ b/src/furigana_ocr/core/__init__.py
@@ -1,19 +1,9 @@
 """Core domain services for capturing, recognising and annotating text."""
 
-from .capture import ScreenCapture
-from .dictionary import DictionaryLookup
-from .models import (
-    BoundingBox,
-    DictionaryEntry,
-    OCRResult,
-    OCRWord,
-    Region,
-    TokenAnnotation,
-    TokenData,
-)
-from .ocr import OCRProcessor
-from .tokenization import Tokenizer
-from .transliteration import FuriganaGenerator
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "BoundingBox",
@@ -29,3 +19,29 @@ __all__ = [
     "TokenData",
     "Tokenizer",
 ]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin lazy import layer
+    if name in __all__:
+        module_map = {
+            "ScreenCapture": "capture",
+            "DictionaryLookup": "dictionary",
+            "Tokenizer": "tokenization",
+            "FuriganaGenerator": "transliteration",
+            "OCRProcessor": "ocr",
+            "BoundingBox": "models",
+            "DictionaryEntry": "models",
+            "OCRResult": "models",
+            "OCRWord": "models",
+            "Region": "models",
+            "TokenAnnotation": "models",
+            "TokenData": "models",
+        }
+        module_name = module_map[name]
+        module = import_module(f"{__name__}.{module_name}")
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - aids interactive use
+    return sorted(__all__ + list(globals().keys()))

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,0 +1,59 @@
+import threading
+from types import SimpleNamespace
+
+import furigana_ocr.core.dictionary as dictionary
+
+
+def test_dictionary_lookup_uses_thread_local_jamdict(monkeypatch):
+    instances: list[int] = []
+    calls: list[tuple[int, str, bool]] = []
+
+    class DummyJamdict:
+        def __init__(self) -> None:
+            self._local = threading.local()
+            # Mimic jamdict initialising thread-local database handles during
+            # construction.  Using the instance from another thread would
+            # normally trigger the AttributeError observed in production.
+            self._local.srcdc = True
+            instances.append(threading.get_ident())
+
+        def lookup(self, surface: str, strict: bool = True):  # pragma: no cover - type stub
+            if not hasattr(self._local, "srcdc"):
+                raise AttributeError("'_thread._local' object has no attribute 'srcdc'")
+            calls.append((threading.get_ident(), surface, strict))
+            return SimpleNamespace(entries=[])
+
+    monkeypatch.setattr(dictionary, "Jamdict", DummyJamdict)
+
+    lookup = dictionary.DictionaryLookup()
+
+    # First call should create a client for the main thread.
+    assert lookup.lookup("猫") == []
+    assert len(instances) == 1
+    assert calls[-1][1] == "猫"
+
+    # Simulate the thread-local attribute being cleared which previously caused
+    # an AttributeError.  The lookup should recover by instantiating a new
+    # client for the current thread.
+    client = lookup._thread_local.jamdict
+    del client._local.srcdc
+    assert lookup.lookup("狐") == []
+    assert len(instances) == 2
+    assert calls[-1][1] == "狐"
+
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            lookup.lookup("犬")
+        except BaseException as exc:  # pragma: no cover - diagnostic helper
+            errors.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+
+    assert not errors
+    # A separate Jamdict instance should be created for the worker thread.
+    assert len(instances) == 3
+    assert calls[-1][1] == "犬"

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from furigana_ocr.core.tokenization import Tokenizer
+
+
+class DummyWord:
+    def __init__(self, surface, feature, dictionary_form=None, reading=None):
+        self.surface = surface
+        self.feature = feature
+        if dictionary_form is not None:
+            self.dictionary_form = dictionary_form
+        if reading is not None:
+            self.reading = reading
+
+
+class DummyTagger:
+    def __init__(self, words):
+        self._words = words
+
+    def __call__(self, text):  # pragma: no cover - behaviour is deterministic
+        return list(self._words)
+
+
+def test_tokenizer_extracts_readings_from_features():
+    tokenizer = Tokenizer()
+    words = [
+        DummyWord(
+            surface="猫",
+            feature=["名詞", "普通名詞", "一般", "*", "*", "*", "猫", "ネコ", "ネコ"],
+            dictionary_form="猫",
+        ),
+        DummyWord(
+            surface="日本",
+            feature="名詞,固有名詞,地域,一般,*,*,日本,ニホン,ニッポン",
+            dictionary_form="日本",
+        ),
+        DummyWord(
+            surface="東京",
+            feature=SimpleNamespace(reading="トウキョウ"),
+            dictionary_form="東京",
+        ),
+    ]
+    tokenizer._tagger = DummyTagger(words)
+
+    tokens = tokenizer.tokenize("猫 日本 東京")
+
+    assert [token.surface for token in tokens] == ["猫", "日本", "東京"]
+    assert tokens[0].reading == "ネコ"
+    assert tokens[1].reading == "ニホン"
+    assert tokens[2].reading == "トウキョウ"


### PR DESCRIPTION
## Summary
- ensure `DictionaryLookup` creates per-thread Jamdict clients and recovers from `_thread._local` failures
- improve tokenizer reading extraction so furigana annotations prefer kana instead of part-of-speech labels
- lazily import core modules and add regression tests for the dictionary and tokenizer helpers

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17a4a621c8325822758b161748225