### PR TITLE
Handle partial OCR word matches in pipeline

### DIFF
--- a/src/furigana_ocr/utils/__init__.py
+++ b/src/furigana_ocr/utils/__init__.py
@@ -1,6 +1,11 @@
 """Shared utility helpers."""
 
-from .geometry import combine_bounding_boxes, region_from_bbox
+from .geometry import combine_bounding_boxes, region_from_bbox, segment_ocr_word
 from .timers import FrequencyController
 
-__all__ = ["combine_bounding_boxes", "region_from_bbox", "FrequencyController"]
+__all__ = [
+    "combine_bounding_boxes",
+    "region_from_bbox",
+    "segment_ocr_word",
+    "FrequencyController",
+]

--- a/src/furigana_ocr/utils/geometry.py
+++ b/src/furigana_ocr/utils/geometry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Iterable, Tuple
 
-from ..core.models import BoundingBox, Region
+from ..core.models import BoundingBox, OCRWord, Region
 
 
 def region_from_bbox(box: BoundingBox) -> Region:
@@ -27,4 +27,44 @@ def combine_bounding_boxes(boxes: Iterable[BoundingBox]) -> BoundingBox:
     return BoundingBox.from_points(points)
 
 
-__all__ = ["combine_bounding_boxes", "region_from_bbox"]
+def segment_ocr_word(word: OCRWord, start: int, length: int) -> Tuple[str, BoundingBox]:
+    """Return a sub-section of ``word`` using approximate geometric splits.
+
+    The helper operates on the number of non-whitespace characters in the
+    ``OCRWord``.  The provided ``start`` and ``length`` arguments are measured in
+    those units.  The function computes an average character width/height and
+    uses it to derive a bounding box that approximates the requested substring.
+    """
+
+    non_ws_chars = [ch for ch in word.text if not ch.isspace()]
+    total = len(non_ws_chars)
+    if total == 0 or length <= 0 or start >= total:
+        return "", BoundingBox(word.bbox.left, word.bbox.top, 0, 0)
+
+    start = max(0, start)
+    end = min(start + length, total)
+    if end <= start:
+        return "", BoundingBox(word.bbox.left, word.bbox.top, 0, 0)
+
+    text = "".join(non_ws_chars[start:end])
+
+    horizontal = word.bbox.width >= word.bbox.height
+    if horizontal:
+        start_pos = word.bbox.left + round(word.bbox.width * start / total)
+        end_pos = word.bbox.left + round(word.bbox.width * end / total)
+        left = min(start_pos, word.bbox.right)
+        right = min(max(end_pos, left + 1), word.bbox.right)
+        width = max(1, right - left)
+        bbox = BoundingBox(left, word.bbox.top, width, word.bbox.height)
+    else:
+        start_pos = word.bbox.top + round(word.bbox.height * start / total)
+        end_pos = word.bbox.top + round(word.bbox.height * end / total)
+        top = min(start_pos, word.bbox.bottom)
+        bottom = min(max(end_pos, top + 1), word.bbox.bottom)
+        height = max(1, bottom - top)
+        bbox = BoundingBox(word.bbox.left, top, word.bbox.width, height)
+
+    return text, bbox
+
+
+__all__ = ["combine_bounding_boxes", "region_from_bbox", "segment_ocr_word"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,142 @@
+"""Tests for the processing pipeline orchestration layer."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import List
+
+
+if "PIL" not in sys.modules:  # pragma: no cover - test isolation shim
+    pil_module = types.ModuleType("PIL")
+    image_module = types.ModuleType("PIL.Image")
+
+    class _Image:  # minimal stand-in to satisfy type hints
+        pass
+
+    image_module.Image = _Image
+    pil_module.Image = image_module
+    sys.modules["PIL"] = pil_module
+    sys.modules["PIL.Image"] = image_module
+
+if "mss" not in sys.modules:  # pragma: no cover - test isolation shim
+    mss_module = types.ModuleType("mss")
+
+    class _MSS:  # minimal stub used for type checking
+        def __enter__(self):  # pragma: no cover - defensive default
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # pragma: no cover - defensive default
+            return False
+
+        def grab(self, monitor):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def close(self):  # pragma: no cover - defensive default
+            return None
+
+    mss_module.mss = _MSS
+    sys.modules["mss"] = mss_module
+
+if "pytesseract" not in sys.modules:  # pragma: no cover - test isolation shim
+    pytesseract_module = types.ModuleType("pytesseract")
+
+    class _PytesseractInner:
+        tesseract_cmd = ""
+
+    def _image_to_data(*args, **kwargs):  # pragma: no cover - not used in test
+        raise NotImplementedError
+
+    pytesseract_module.pytesseract = _PytesseractInner()
+    pytesseract_module.image_to_data = _image_to_data
+    pytesseract_module.Output = types.SimpleNamespace(DICT="DICT")
+    sys.modules["pytesseract"] = pytesseract_module
+
+if "pykakasi" not in sys.modules:  # pragma: no cover - test isolation shim
+    pykakasi_module = types.ModuleType("pykakasi")
+
+    class _Converter:
+        def do(self, text):  # pragma: no cover - not used in test
+            return text
+
+    class _Kakasi:
+        def setMode(self, *args, **kwargs):  # pragma: no cover - defensive default
+            return None
+
+        def getConverter(self):  # pragma: no cover - defensive default
+            return _Converter()
+
+    def _kakasi():  # pragma: no cover - defensive default
+        return _Kakasi()
+
+    pykakasi_module.kakasi = _kakasi
+    sys.modules["pykakasi"] = pykakasi_module
+
+from furigana_ocr.config import AppConfig
+from furigana_ocr.core.models import BoundingBox, OCRResult, OCRWord, TokenData
+from furigana_ocr.services.pipeline import PipelineDependencies, ProcessingPipeline
+
+
+class _DummyCapture:
+    def capture(self, region):  # pragma: no cover - not used in test
+        raise NotImplementedError
+
+
+class _DummyOCR:
+    def run(self, image):  # pragma: no cover - not used in test
+        raise NotImplementedError
+
+
+class _DummyTokenizer:
+    def tokenize(self, text: str) -> List[TokenData]:  # pragma: no cover - not used in test
+        return []
+
+
+class _DummyFurigana:
+    def reading_for(self, surface: str):  # pragma: no cover - not used in test
+        return None
+
+
+class _DummyDictionary:
+    def lookup(self, surface: str):  # pragma: no cover - not used in test
+        return []
+
+
+def _build_pipeline() -> ProcessingPipeline:
+    config = AppConfig()
+    deps = PipelineDependencies(
+        capture=_DummyCapture(),
+        ocr=_DummyOCR(),
+        tokenizer=_DummyTokenizer(),
+        furigana=_DummyFurigana(),
+        dictionary=_DummyDictionary(),
+    )
+    return ProcessingPipeline(config, deps=deps)
+
+
+def test_match_words_returns_bounding_boxes_for_substrings() -> None:
+    pipeline = _build_pipeline()
+    word = OCRWord(
+        text="今天天氣真好",
+        confidence=85.0,
+        bbox=BoundingBox(left=10, top=20, width=120, height=30),
+        order=0,
+    )
+    ocr_result = OCRResult(text="今天天氣真好", words=[word])
+    tokens = [
+        TokenData(surface="今天"),
+        TokenData(surface="天氣"),
+        TokenData(surface="真好"),
+    ]
+
+    annotations = pipeline._enrich(tokens, ocr_result)
+
+    assert [annotation.token.surface for annotation in annotations] == [
+        "今天",
+        "天氣",
+        "真好",
+    ]
+    for annotation in annotations:
+        assert annotation.bbox is not None
+        assert annotation.bbox.width > 0
+        assert annotation.bbox.height > 0


### PR DESCRIPTION
## Summary
- track intra-word character offsets while matching OCR words to tokens
- add a geometry helper to segment OCR bounding boxes for substring matches
- cover substring matching with a pipeline unit test using "今天天氣真好"

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b520704c83258cbc3032a674c267