### PR TITLE
Add furigana color controls and hover highlighting

### DIFF
--- a/src/furigana_ocr/config.py
+++ b/src/furigana_ocr/config.py
@@ -38,6 +38,7 @@ class OverlayConfig:
     font_size: int = 18
     furigana_font_size: int = 11
     background_opacity: float = 0.0
+    furigana_color: tuple[int, int, int] = (255, 200, 150)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- add a configurable furigana color to the overlay configuration
- expose RGB sliders with a live preview in the main window to tweak furigana rendering
- draw bold outlined furigana and show a transparent hover border that follows the selected color

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2cf98d0948325889bfce3ab578ff2